### PR TITLE
Rename NPM lib to node-databox

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To use this library in your node project, run:
 
 and then within your project:
 
-	const databox = require('databox');
+	const databox = require('node-databox');
 
 Usage
 -----

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "databox",
+  "name": "node-databox",
   "version": "0.1.0",
   "description": "A Nodejs library for interfacing with Databox APIs",
   "main": "databox.js",


### PR DESCRIPTION
Because "databox" is already taken by the people who own databox.com. This seems to be the convention for name clashes. Lives here now: https://www.npmjs.com/package/node-databox.