### PR TITLE
Add function for waiting for stores to become active

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ Usage
 
 > :warning: While this library is at [0.X.X](http://semver.org/spec/v2.0.0.html) the API may change.
 
+### waitForStoreStatus(href, status, maxRetries=10) ###
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _href_ | `String` | The store href |
+| _status_ | `String` | The status to wait for (e.g. 'active' or 'standby') |
+| _maxRetries_ | `Number` | Optional number of times to retry before timing out (default 10) |
+
+**Returns** A `Promise` that resolves when a store status matches `status` or rejects with an error.
+
 ### catalog.getRootCatalog() ###
 
 **Returns** A `Promise` that resolves with a JSON object of root catalog or rejects with an error.

--- a/databox.js
+++ b/databox.js
@@ -1,4 +1,5 @@
-exports.catalog       = require('./lib/catalog.js');
-exports.timeseries    = require('./lib/time-series.js');
-exports.keyValue      = require('./lib/key-value.js');
-exports.subscriptions = require('./lib/subscriptions.js');
+exports.waitForStoreStatus = require('./lib/utils.js').waitForStoreStatus;
+exports.catalog            = require('./lib/catalog.js');
+exports.timeseries         = require('./lib/time-series.js');
+exports.keyValue           = require('./lib/key-value.js');
+exports.subscriptions      = require('./lib/subscriptions.js');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -90,3 +90,28 @@ exports.requestToken = function(hostname, endpoint, method) {
 	});
 };
 
+exports.waitForStoreStatus = function() {
+	function retry(func, maxRetries, test) {
+		test = test || (()=>{});
+		let promise = Promise.reject();
+		for (let i = 0; i < maxRetries; ++i)
+			promise = promise.catch(() => func()).then(test);
+		return promise;
+	}
+
+	return function(href, status, maxRetries) {
+		maxRetries = maxRetries || 10;
+
+		return new Promise((resolve, reject) => {
+			retry(() => {
+				return exports.makeStoreRequest({
+					method: 'GET',
+					url: href + '/status'
+				});
+			}, maxRetries, (body) => {
+				if (body !== status)
+					throw new Error('Status not ' + status);
+			}).then(resolve).catch(reject);
+		});
+	};
+}();


### PR DESCRIPTION
Are there any use cases for app/driver devs needing to detect status changes? Seems like store do either `nothing` or 'active', in which case this should be good to go. Otherwise, might need to add an optional delay between retries or maybe even something a bit more clever like an exponential backoff.