### PR TITLE
Make subscriptions over wss

### DIFF
--- a/lib/subscriptions.js
+++ b/lib/subscriptions.js
@@ -4,18 +4,36 @@ const url = require('url');
 const EventEmitter = require('events');
 
 const WebSocket = require('ws');
+const https = require('https');
+
+// Configure HTTPS agent (as in stores)
+const CM_HTTPS_CA_ROOT_CERT = process.env.CM_HTTPS_CA_ROOT_CERT;
+var agentOptions = {};
+if (!CM_HTTPS_CA_ROOT_CERT) {
+	console.warn('Warning: No HTTPS root certficate provided so Databox HTTPS certificates will not be checked');
+	agentOptions.rejectUnauthorized = false;
+} else {
+	agentOptions.ca = CM_HTTPS_CA_ROOT_CERT;
+}
+var httpsAgent = new https.Agent(agentOptions);
 
 exports.connect = function (href) {
 	return new Promise((resolve, reject) => {
 		var storeURL = url.parse(href);
-		utils.requestToken(storeURL.hostname, '/ws', 'GET').then((token) => {
-			var ws = new WebSocket('ws://' + storeURL.host + '/ws', null, { 'X-Api-Key': token });
+		console.log("[connect] requesting token for", storeURL.hostname, '/ws', 'GET');
+		utils.requestToken(storeURL.hostname, '/ws', 'GET')
+		.then((token) => {
+			console.log("[WS connecting] to ", 'wss://' + storeURL.host + '/ws');
+			var ws = new WebSocket('wss://' + storeURL.host + '/ws', null, { 'x-api-key': token, 'agent': httpsAgent});
 			var notifications = new EventEmitter();
 			ws.on('open', () => notifications.emit('open'));
 			ws.on('message', (data) => {
 				// TODO: Handle exception
 				data = JSON.parse(data);
 				notifications.emit('data', storeURL.hostname, data.datasource_id, data.data);
+			});
+			ws.on('error',(error)=>{
+				notifications.emit('error',error);
 			});
 			resolve(notifications);
 		}).catch((err) => reject(err));

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -65,8 +65,8 @@ exports.makeStoreRequest = function() {
 
 				return new Promise((resolve, reject) => {
 					request(options, (err, res, body) => {
-						if (err || res.statusCode !== 201) {
-							reject(err || body);
+						if (err || (res.statusCode < 200 && res.statusCode >= 300)) {
+							reject(err || body || "[API Error]" + res.statusCode);
 							return;
 						}
 						resolve(body);


### PR DESCRIPTION
**Don't merge. For discussion.**

Websocket subscriptions should be over wss this patch attempts to do this. However, I've tried a number of configurations but still get the following.  

{ Error: unable to verify the first certificate
    at TLSSocket.<anonymous> (_tls_wrap.js:1079:38)
    at emitNone (events.js:86:13)
    at TLSSocket.emit (events.js:185:7)
    at TLSSocket._finishInit (_tls_wrap.js:603:8)
    at TLSWrap.ssl.onhandshakedone (_tls_wrap.js:433:38) code: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE' }

Any thoughts @yousefamar 