### PR TITLE
Improve API methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Usage
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _href_ | `String` | The store href |
+| _href_ | `String` | The store or datasource href |
 | _status_ | `String` | The status to wait for (e.g. 'active' or 'standby') |
 | _maxRetries_ | `Number` | Optional number of times to retry before timing out (default 10) |
 
@@ -39,7 +39,7 @@ Usage
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _href_ | `String` | The store href |
+| _href_ | `String` | The store or datasource href |
 
 **Returns** A `Promise` that resolves with a JSON object of a store catalog or rejects with an error.
 
@@ -70,7 +70,7 @@ A convenience function for listing available stores.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _href_     | `String` | The store href |
+| _href_     | `String` | The store or datasource href |
 | _metadata_ | `Object` | Dataource metadata |
 
 **Example**
@@ -92,7 +92,21 @@ A convenience function for listing available stores.
 
 **Returns** A `Promise` that resolves or rejects with an error
 
+### timeseries.latest(href) ###
+
+Reads the latest entry from a given time series datasource
+
+**Parameters**
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _href_ | `String` | The target datasource href |
+
+**Returns** A `Promise` that resolves with the latest entry for this timeseries datasource or rejects with an error
+
 ### timeseries.latest(href, dataSourceID) ###
+
+> :warning: Deprecated
 
 Reads the latest entry from a given time series store
 
@@ -105,7 +119,22 @@ Reads the latest entry from a given time series store
 
 **Returns** A `Promise` that resolves with the latest entry for this timeseries data store endpoint or rejects with an error
 
+### timeseries.since(href, startTimestamp) ###
+
+Reads since a given range from a given time series datasource
+
+**Parameters**
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _href_           | `String` | The target datasource href |
+| _startTimestamp_ | `Number` | The timestamp from which to query time series data (inclusive) |
+
+**Returns** A `Promise` that resolves with an array of data for this timeseries datasource or rejects with an error
+
 ### timeseries.since(href, dataSourceID, startTimestamp) ###
+
+> :warning: Deprecated
 
 Reads since a given range from a given time series store
 
@@ -119,7 +148,23 @@ Reads since a given range from a given time series store
 
 **Returns** A `Promise` that resolves with an array of data for this timeseries data store endpoint or rejects with an error
 
+### timeseries.range(href, startTimestamp, endTimestamp) ###
+
+Reads in given range from a given time series datasource
+
+**Parameters**
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _href_           | `String` | The target datasource href |
+| _startTimestamp_ | `Number` | The timestamp from which to query time series data (inclusive) |
+| _endTimestamp_   | `Number` | The timestamp to which to query time series data (inclusive) |
+
+**Returns** A `Promise` that resolves with an array of data for this timeseries datasource or rejects with an error
+
 ### timeseries.range(href, dataSourceID, startTimestamp, endTimestamp) ###
+
+> :warning: Deprecated
 
 Reads in given range from a given time series store
 
@@ -134,7 +179,22 @@ Reads in given range from a given time series store
 
 **Returns** A `Promise` that resolves with an array of data for this timeseries data store endpoint or rejects with an error
 
+### timeseries.write(href, data) ###
+
+Writes to a given time series datasource
+
+**Parameters**
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _href_ | `String` | The target datasource href |
+| _data_ | `Object` | An object to write to a datasource time series |
+
+**Returns** A `Promise` that resolves with the document written to the store (including automatically added timestamp) or rejects with an error
+
 ### timeseries.write(href, dataSourceID, data) ###
+
+> :warning: Deprecated
 
 Writes to a given time series store
 
@@ -148,7 +208,21 @@ Writes to a given time series store
 
 **Returns** A `Promise` that resolves with the document written to the store (including automatically added timestamp) or rejects with an error
 
-### keyValue.read(href, dataSourceID) ###
+### keyValue.read(href) ###
+
+Reads from a given key-value datasource
+
+**Parameters**
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _href_ | `String` | The target datasource href |
+
+**Returns** A `Promise` that resolves with the document at this endpoint or rejects with an error
+
+### keyValue.read(href, key) ###
+
+> :warning: Deprecated
 
 Reads from a given key-value store
 
@@ -161,7 +235,22 @@ Reads from a given key-value store
 
 **Returns** A `Promise` that resolves with the document at this endpoint or rejects with an error
 
-### keyValue.write(href, dataSourceID, data) ###
+### keyValue.write(href, data) ###
+
+Writes to a given key-value datasource
+
+**Parameters**
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _href_ | `String` | The target datasource href |
+| _data_ | `Object` | The value to write |
+
+**Returns** A `Promise` that resolves with the document written to the store or rejects with an error
+
+### keyValue.write(href, key, data) ###
+
+> :warning: Deprecated
 
 Writes to a given key-value store
 
@@ -183,11 +272,26 @@ Connects to a target store's notification service
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| _href_ | `String` | The target store href |
+| _href_ | `String` | The target store or datasource href |
 
 **Returns** A `Promise` that resolves with an `EventEmitter` that emits `open` when the notification stream is opened, and `data` with store write event notifications of data for every route the connecting container is subscribed to. The callback function for that event has three parameters: `hostname` (the source store), `datasourceID` (the triggering datasource), and `data` which is the data actually written to the store. Otherwise if there's an error setting up the connection, the `Promise` rejects with an error.
 
+### subscriptions.subscribe(href, type) ###
+
+Subscribes the caller to write notifications for a given route
+
+**Parameters**
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _href_ | `String` | The target datasource href |
+| _type_ | `String` | "ts" for time series stores or "kv" for key-value stores |
+
+**Returns** A `Promise` that resolves silently if the subscription was a success or rejects with an error
+
 ### subscriptions.subscribe(href, dataSourceID, type) ###
+
+> :warning: Deprecated
 
 Subscribes the caller to write notifications for a given route
 
@@ -197,11 +301,26 @@ Subscribes the caller to write notifications for a given route
 | ---- | ---- | ----------- |
 | _href_         | `String` | The target store href |
 | _dataSourceID_ | `String` | The target datasource ID |
-| _type_         | `String` | "ts" for time series stores or "key" for key-value stores |
+| _type_         | `String` | "ts" for time series stores or "kv" for key-value stores |
 
 **Returns** A `Promise` that resolves silently if the subscription was a success or rejects with an error
 
+### subscrciptions.unsubscribe(href, type) ###
+
+Unsubscribes the caller to write notifications for a given route
+
+**Parameters**
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| _href_ | `String` | The target datasource href |
+| _type_ | `String` | "ts" for time series stores or "kv" for key-value stores |
+
+**Returns** A `Promise` that resolves silently if the unsubscription was a success or rejects with an error
+
 ### subscrciptions.unsubscribe(href, dataSourceID, type) ###
+
+> :warning: Deprecated
 
 Unsubscribes the caller to write notifications for a given route
 
@@ -211,7 +330,7 @@ Unsubscribes the caller to write notifications for a given route
 | ---- | ---- | ----------- |
 | _href_         | `String` | The target store href |
 | _dataSourceID_ | `String` | The target datasource ID |
-| _type_         | `String` | "ts" for time series stores or "key" for key-value stores |
+| _type_         | `String` | "ts" for time series stores or "kv" for key-value stores |
 
 **Returns** A `Promise` that resolves silently if the unsubscription was a success or rejects with an error
 
@@ -230,7 +349,7 @@ Exports data and retrieves response via long polling
 
 ### export.queue(destination, payload) ###
 
-NB: Currently unimplemented
+> :warning: Currently unimplemented
 
 Pushes data to an export queue and retrieves response via polling
 

--- a/lib/catalog.js
+++ b/lib/catalog.js
@@ -7,6 +7,7 @@ exports.getRootCatalog = function() {
 };
 
 exports.getStoreCatalog = function(href) {
+	href = (url => url.protocol + '//' + url.host)(url.parse(href));
 	return utils.makeStoreRequest({
 		method: 'GET',
 		json: true,
@@ -56,6 +57,7 @@ exports.mapStoreCatalogs = function(callback, thisArg) {
 };
 
 exports.registerDatasource = function(href, metadata) {
+	href = (url => url.protocol + '//' + url.host)(url.parse(href));
 	return new Promise((resolve, reject) => {
 		if (!metadata
 			  || !metadata.description

--- a/lib/key-value.js
+++ b/lib/key-value.js
@@ -1,17 +1,19 @@
 const utils = require('./utils.js');
 
 exports.read = function(href, key) {
+	key && (href += '/' + key);
 	return utils.makeStoreRequest({
 		method: 'GET',
 		json: true,
-		url: href + '/' + key + '/kv'
+		url: href + '/kv'
 	});
 };
 
 exports.write = function(href, key, data) {
+	data ? href += '/' + key : data = key;
 	return utils.makeStoreRequest({
 		method: 'POST',
 		json: data,
-		url: href + '/' + key + '/kv'
+		url: href + '/kv'
 	});
 };

--- a/lib/subscriptions.js
+++ b/lib/subscriptions.js
@@ -34,6 +34,12 @@ exports.connect = function (href) {
 };
 
 exports.subscribe = function(href, dataSourceID, type) {
+	if (!type) {
+		type = dataSourceID;
+		var dsURL = url.parse(href);
+		href = dsURL.protocol + '//' + dsURL.host;
+		dataSourceID = dsURL.pathname;
+	}
 	return utils.makeStoreRequest({
 		method: 'GET',
 		url: href + '/sub/' + dataSourceID + '/' + type
@@ -41,6 +47,12 @@ exports.subscribe = function(href, dataSourceID, type) {
 };
 
 exports.unsubscribe = function(href, dataSourceID, type) {
+	if (!type) {
+		type = dataSourceID;
+		var dsURL = url.parse(href);
+		href = dsURL.protocol + '//' + dsURL.host;
+		dataSourceID = dsURL.pathname;
+	}
 	return utils.makeStoreRequest({
 		method: 'GET',
 		url: href + '/unsub/' + dataSourceID + '/' + type

--- a/lib/time-series.js
+++ b/lib/time-series.js
@@ -1,33 +1,37 @@
 const utils = require('./utils.js');
 
 exports.latest = function(href, dataSourceID) {
+	dataSourceID && (href += '/' + dataSourceID);
 	return utils.makeStoreRequest({
 		method: 'GET',
 		json: true,
-		url: href + '/' + dataSourceID + '/ts/latest'
+		url: href + '/ts/latest'
 	});
 };
 
 exports.since = function(href, dataSourceID, startTimestamp) {
+	startTimestamp ? href += '/' + dataSourceID : startTimestamp = dataSourceID;
 	return utils.makeStoreRequest({
 		method: 'GET',
-		url: href + '/' + dataSourceID + '/ts/since',
+		url: href + '/ts/since',
 		json: { startTimestamp }
 	});
 };
 
 exports.range = function(href, dataSourceID, startTimestamp, endTimestamp) {
+	endTimestamp ? href += '/' + dataSourceID : (endTimestamp = startTimestamp, startTimestamp = dataSourceID);
 	return utils.makeStoreRequest({
 		method: 'GET',
-		url: href + '/' + dataSourceID + '/ts/range',
+		url: href + '/ts/range',
 		json: { startTimestamp, endTimestamp }
 	});
 };
 
 exports.write = function(href, dataSourceID, data) {
+	data ? href += '/' + dataSourceID : data = dataSourceID;
 	return utils.makeStoreRequest({
 		method: 'POST',
 		json: { data: data },
-		url: href + '/' + dataSourceID + '/ts'
+		url: href + '/ts'
 	});
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -93,6 +93,7 @@ exports.requestToken = function(hostname, endpoint, method) {
 };
 
 exports.waitForStoreStatus = function (href, status, maxRetries) {
+	href = (url => url.protocol + '//' + url.host)(url.parse(href));
 	return promiseRetry(function (retry, number) {
 		return exports.makeStoreRequest({
 			method: 'GET',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-databox",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A Nodejs library for interfacing with Databox APIs",
   "main": "databox.js",
   "scripts": {


### PR DESCRIPTION
Resolves https://github.com/me-box/databox/issues/5 and closes #12.

I've decided that datasource hrefs (e.g. DATASOURCE_DS_light.href) are what identify data sources. The datasource ID is already contained within them, and the fact that a metadata rel will always contains the same ID is just a redundancy — the href should take precedence. This also fits with some APIs like `/(un)sub/*` and future ones, since those deal directly with URLs too.

  - Methods that deal with store URLs now don't care if you pass them store URLs or full datasource URLs. These include `waitForStoreStatus`, `catalog.getStoreCatalog`, `catalog.registerDatasource`, and `subscriptions.connect` (that one never cared to begin with)
  - Methods that previously split store and datasource arguments, now accept a single URL too

This PR changes API methods, however it is fully backwards compatible. I've left any old methods that take different arguments in the documentation alongside the new ones and simply marked them "deprecated". When we increment to 1.0.0, I'll take them out completely. Apps/drivers that use the old functions and upgrade to a newer lib version won't break.